### PR TITLE
Fixes from hjh: print first, use interpretPrintCmdLine, unused classvar

### DIFF
--- a/Troop.sc
+++ b/Troop.sc
@@ -1,9 +1,5 @@
-Troop
-{
-	classvar verbose;
-
-	*start
-	{
+Troop {
+	*start {
 		arg verbose = false;
 
 		'Listening for messages from Troop.'.postln;
@@ -13,21 +9,27 @@ Troop
 		OSCFunc(
 			{
 				arg msg, time, addr, port;
+				var interp;
+
+				// If the verbose flag is True, print the code
+
+				if (verbose == true){
+					msg[1].asString.postln;
+				};
 
 				// Only interpret code sent from a local ip address
 
-				if (NetAddr.matchLangIP(addr.ip) == true){
-					msg[1].asString.interpret;
-				}{
+				if (NetAddr.matchLangIP(addr.ip) == true) {
+					defer {
+						thisProcess.interpreter
+						.cmdLine_(msg[1].asString)
+						.interpretPrintCmdLine;
+					}
+				} {
 					'Warning: external Troop message attempted from'.postln;
 					addr.postln;
 				};
 
-				// If the verbose flag is True, print the code
-
-				if (verbose==true){
-					msg[1].asString.postln;
-				}{};
 			},
 			'troop'
 		);


### PR DESCRIPTION
I was investigating Troop for networked performance, and noticed a couple of issues in the SC quark.

- Interpreting the string should be wrapped in `defer` so that user commands can address GUI objects.

- Interpreting the string should go through `interpretPrintCmdLine` for several reasons:
  - Print the result of the expression (give some feedback to the user).
  - Use the interpreter's preprocessor. This is especially important for live coding!

- If `verbose` is true, print the command string before evaluating, not after.
  - So that the feedback in the post window is the command, followed by the result.
  - So that the command is always printed, even if evaluation hits an error.

- `verbose` is a method argument, so the `classvar verbose` is never used. (So I removed it.)

Thanks.